### PR TITLE
ci: skip caching of node_modules

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,19 +18,7 @@ jobs:
     steps:
       - checkout
 
-      # Download and cache dependencies
-      - restore_cache:
-          keys:
-            - v1-dependencies-{{ checksum "package.json" }}
-            # fallback to using the latest cache if no exact match is found
-            - v1-dependencies-
-
       - run: npm ci
-
-      - save_cache:
-          paths:
-            - node_modules
-          key: v1-dependencies-{{ checksum "package.json" }}
 
       - persist_to_workspace:
           root: .


### PR DESCRIPTION
I have no idea why I originally did it this way but it makes no sense.

- restore node_modules from cache (if any)
- run `npm ci`
  - delete node_modules
  - recreate node_modules from scratch
- save node_modules into cache

The caching is completely pointless as it's restored just to be deleted right away. It just wastes about a minute of time per workflow.