### PR TITLE
fix(deps): support UUID v14 and use it in standalone/peer exports

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,11 +20,11 @@
         "shx": "0.4.0",
         "snap-shot-it": "7.9.10",
         "uuid": "14.0.0",
-        "vis-data": "8.0.3",
+        "vis-data": "8.0.4",
         "vis-dev-utils": "6.0.1",
-        "vis-graph3d": "7.0.2",
-        "vis-network": "10.0.2",
-        "vis-timeline": "8.5.0",
+        "vis-graph3d": "7.0.3",
+        "vis-network": "10.0.3",
+        "vis-timeline": "8.5.1",
         "vis-util": "6.0.0"
       },
       "funding": {
@@ -11252,9 +11252,9 @@
       }
     },
     "node_modules/vis-data": {
-      "version": "8.0.3",
-      "resolved": "https://registry.npmjs.org/vis-data/-/vis-data-8.0.3.tgz",
-      "integrity": "sha512-jhnb6rJNqkKR1Qmlay0VuDXY9ZlvAnYN1udsrP4U+krgZEq7C0yNSKdZqmnCe13mdnf9AdVcdDGFOzy2mpPoqw==",
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/vis-data/-/vis-data-8.0.4.tgz",
+      "integrity": "sha512-TsN0sMHqIRpdfg6TNPtfdINpkgxtnQP6JNWCaiSwvou5seXqKiP5eERkaBg+Y56wyJ4FZTeOEs/dEmWEPrpltQ==",
       "dev": true,
       "license": "(Apache-2.0 OR MIT)",
       "funding": {
@@ -11262,7 +11262,7 @@
         "url": "https://opencollective.com/visjs"
       },
       "peerDependencies": {
-        "uuid": "^3.4.0 || ^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0 || ^13.0.0",
+        "uuid": "^3.4.0 || ^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0 || ^13.0.0 || ^14.0.0",
         "vis-util": ">=6.0.0"
       }
     },
@@ -11363,9 +11363,9 @@
       }
     },
     "node_modules/vis-graph3d": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/vis-graph3d/-/vis-graph3d-7.0.2.tgz",
-      "integrity": "sha512-fcnHGyVOCLFbzuAOeqSQzZih6qzuYCx2fmPc8YzWuT/ZQxZvn/BkECVEr+0Dq3KSpiKCXXXqleEtL0hXdUt72Q==",
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/vis-graph3d/-/vis-graph3d-7.0.3.tgz",
+      "integrity": "sha512-Y0IHKdwSXwoPPWTMr4JT9la3b6AjDavc7IUj6OOdZWmYUQEEPtXEcGACRVCK2/KQBawjR69B1XxVdP1iKGfKRg==",
       "dev": true,
       "license": "(Apache-2.0 OR MIT)",
       "funding": {
@@ -11376,15 +11376,15 @@
         "@egjs/hammerjs": "^2.0.0",
         "component-emitter": "^1.3.0 || ^2.0.0",
         "keycharm": "^0.2.0 || ^0.3.0 || ^0.4.0",
-        "uuid": "^3.4.0 || ^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0 || ^13.0.0",
+        "uuid": "^3.4.0 || ^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0 || ^13.0.0 || ^14.0.0",
         "vis-data": ">=8.0.0",
         "vis-util": ">=6.0.0"
       }
     },
     "node_modules/vis-network": {
-      "version": "10.0.2",
-      "resolved": "https://registry.npmjs.org/vis-network/-/vis-network-10.0.2.tgz",
-      "integrity": "sha512-qPl8GLYBeHEFqiTqp4VBbYQIJ2EA8KLr7TstA2E8nJxfEHaKCU81hQLz7hhq11NUpHbMaRzBjW5uZpVKJ45/wA==",
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/vis-network/-/vis-network-10.0.3.tgz",
+      "integrity": "sha512-Sk8qoyY4oi8o5dh8bHsKTTtHi8wWZABbLpH0Ac95ULqVuBIFbMng95QJmEKP8kIQlkjbq3ChJrk1bPmig9Cxig==",
       "dev": true,
       "license": "(Apache-2.0 OR MIT)",
       "funding": {
@@ -11395,15 +11395,15 @@
         "@egjs/hammerjs": "^2.0.0",
         "component-emitter": "^1.3.0 || ^2.0.0",
         "keycharm": "^0.2.0 || ^0.3.0 || ^0.4.0",
-        "uuid": "^3.4.0 || ^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0 || ^13.0.0",
+        "uuid": "^3.4.0 || ^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0 || ^13.0.0 || ^14.0.0",
         "vis-data": ">=8.0.0",
         "vis-util": ">=6.0.0"
       }
     },
     "node_modules/vis-timeline": {
-      "version": "8.5.0",
-      "resolved": "https://registry.npmjs.org/vis-timeline/-/vis-timeline-8.5.0.tgz",
-      "integrity": "sha512-u0+UUuk8qJTxf2SdQ0z0ckCjtks0ECRrjAipbmCZd6vEPf6USGXxeoi7ilRilTU8iVzVE3P0W5TLWzei5KuPfQ==",
+      "version": "8.5.1",
+      "resolved": "https://registry.npmjs.org/vis-timeline/-/vis-timeline-8.5.1.tgz",
+      "integrity": "sha512-6pqx4Zl/xHCEy5nXRaz9xCOx1HtZWkxSIt1oHJmDZy/UxT09kwq1eA4eKRAzhHey3PN1Ee3DsxuxHm7yI2G2mQ==",
       "dev": true,
       "license": "(Apache-2.0 OR MIT)",
       "funding": {
@@ -11416,7 +11416,7 @@
         "keycharm": "^0.2.0 || ^0.3.0 || ^0.4.0",
         "moment": "^2.24.0",
         "propagating-hammerjs": "^1.4.0 || ^2.0.0 || ^3.0.0",
-        "uuid": "^3.4.0 || ^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0 || ^13.0.0",
+        "uuid": "^3.4.0 || ^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0 || ^13.0.0 || ^14.0.0",
         "vis-data": ">=8.0.0",
         "vis-util": ">=6.0.0",
         "xss": "^1.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "propagating-hammerjs": "3.0.0",
         "shx": "0.4.0",
         "snap-shot-it": "7.9.10",
-        "uuid": "13.0.2",
+        "uuid": "14.0.0",
         "vis-data": "8.0.3",
         "vis-dev-utils": "6.0.1",
         "vis-graph3d": "7.0.2",
@@ -11157,9 +11157,9 @@
       "peer": true
     },
     "node_modules/uuid": {
-      "version": "13.0.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-13.0.2.tgz",
-      "integrity": "sha512-vzi9uRZ926x4XV73S/4qQaTwPXM2JBj6/6lI/byHH1jOpCzb0zDbfytgA9LcN/hzb2l7WQSQnxITOVx5un/wGw==",
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
+      "integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
       "dev": true,
       "funding": [
         "https://github.com/sponsors/broofa",

--- a/package.json
+++ b/package.json
@@ -230,7 +230,7 @@
     "propagating-hammerjs": "3.0.0",
     "shx": "0.4.0",
     "snap-shot-it": "7.9.10",
-    "uuid": "13.0.2",
+    "uuid": "14.0.0",
     "vis-data": "8.0.3",
     "vis-dev-utils": "6.0.1",
     "vis-graph3d": "7.0.2",

--- a/package.json
+++ b/package.json
@@ -231,11 +231,11 @@
     "shx": "0.4.0",
     "snap-shot-it": "7.9.10",
     "uuid": "14.0.0",
-    "vis-data": "8.0.3",
+    "vis-data": "8.0.4",
     "vis-dev-utils": "6.0.1",
-    "vis-graph3d": "7.0.2",
-    "vis-network": "10.0.2",
-    "vis-timeline": "8.5.0",
+    "vis-graph3d": "7.0.3",
+    "vis-network": "10.0.3",
+    "vis-timeline": "8.5.1",
     "vis-util": "6.0.0"
   }
 }


### PR DESCRIPTION
Addresses https://github.com/advisories/GHSA-w5hq-g745-h8pq in
standalone and peer exports where we had pinned a vulnerable version.